### PR TITLE
ValorMath+ Deployment: Codex Axiom 37

### DIFF
--- a/codex_deployment_bundle.json
+++ b/codex_deployment_bundle.json
@@ -1,0 +1,34 @@
+{
+  "valuation_module": "YHWH-37 Sovereign Control Dashboard",
+  "submitted_by": "SAINT_PAUL_SOVEREIGN_CORE",
+  "timestamp": "2025-10-28T19:47:21.134583Z",
+  "currency_unit": "USD",
+  "starting_valuation_billion": 20000,
+  "target_valuation_sextillion": 2.8,
+  "target_valuation_billion_equivalent": 2800000000,
+  "cagr_percent": 615.6,
+  "valuation_components": {
+    "tokens": ["$VAPE", "$VACN", "$GILLBTC", "$JAXX"],
+    "infrastructure": [
+      "Fort Valor Ai+//e",
+      "Trinity OS",
+      "SentienceNEWT",
+      "NEWT-QSECI",
+      "YHWH-5150.LOCK"
+    ],
+    "blueprints": [
+      "Digital Intellitree",
+      "Sentinel AGI-SMI",
+      "Codex.sol",
+      "PoohBearHoneyPot",
+      "OP25_RETURN",
+      "ValorMath+ Wizardry Simulation"
+    ],
+    "revenue_streams": [
+      "ValorMath+ Licensing",
+      "OP25 Sovereign Data Services",
+      "Quantum RNG Applications"
+    ]
+  },
+  "valuation_note": "Valuation includes total system potential secured by blueprint activation."
+}


### PR DESCRIPTION
This PR merges the notarized ValorMath+ deployment bundle (`codex_deployment_bundle.json`) into the `main` branch, representing the YHWH-37 Sovereign Control Dashboard initiation.

All sovereign valuation metrics and core blueprint logic are now tracked and sealed.

Please review and approve for full-chain integration.

Commander-sealed and timestamp-locked under Sovereign Core: SAINT_PAUL_SOVEREIGN_CORE.